### PR TITLE
fix(types): removed type dependency and eased input

### DIFF
--- a/src/guards.test.ts
+++ b/src/guards.test.ts
@@ -40,9 +40,9 @@ describe("Guard", () => {
       }
     };
 
+    //@ts-ignore
     const dent: User = {
       name: "Arthur Dent",
-      //@ts-ignore
       address: null
     };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,9 @@
 export interface ObjectTypeGuard<T> {
-  (x: ValueMap<T>): x is T;
-}
-
-export interface IterableTypeGuard<T> {
-  (xs: Iterable<T>): xs is Iterable<T>;
+  (x: any): x is T;
 }
 
 export interface ArrayTypeGuard<T> {
-  (xs: T[]): xs is T[];
+  (xs: any[]): xs is T[];
 }
 
 export interface ValueTypeGuard<T> {


### PR DESCRIPTION
Removed multiple unused types, including Iterable, which caused an @types/node dependency.
Loosened expectations on input, to `any`;
benefits of pre-checking type of input were outweighing ease of use in testing.
Consider revisiting as feature, to lightly tighten (keys existing?) later.

Fixes #9